### PR TITLE
Add types export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "browser": "./dist/yieldparser.module.js",
       "import": "./dist/yieldparser.module.js",
       "require": "./dist/yieldparser.js"


### PR DESCRIPTION
This PR adds the "types" field to the exports in the package.json pointed to the generated `dist/index.d.ts`.

Without it, my project was unable to pull any types for yieldparser, which made it a tad bit harder to work with.

This is the error typsecript reported:

```
Could not find a declaration file for module 'yieldparser'. 'node_modules/yieldparser/dist/yieldparser.module.js' implicitly has an 'any' type.
  There are types at 'node_modules/yieldparser/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'yieldparser' library may need to update its package.json or typings.
```

Let me know if you find any issues.

Also thanks for creating such a cool parser generator. I've found it really nice for things that are too complex for regex but not so much that I'd want to write a whole grammar for